### PR TITLE
Add getEntryLauncher method

### DIFF
--- a/launcher-processor/src/main/kotlin/com/moriatsushi/launcher/processor/CodeBuilder.kt
+++ b/launcher-processor/src/main/kotlin/com/moriatsushi/launcher/processor/CodeBuilder.kt
@@ -73,6 +73,7 @@ internal class CodeBuilder {
 
         package ${function.packageName}
 
+        import android.content.Context
         import android.content.Intent
         import androidx.compose.runtime.Composable
         import androidx.compose.runtime.remember
@@ -82,18 +83,18 @@ internal class CodeBuilder {
         @Composable
         fun remember$launcherName(): $launcherName {
             val context = LocalContext.current
-            return remember {
-                object : $launcherName {
-                    override fun launch() {
-                        val intent = Intent(context, $activityName::class.java)
-                        ${if (!isDefault) "intent.putExtra(\"launcher_destination\", \"${function.qualifiedName}\")" else ""}
-                        context.startActivity(intent)
-                    }
-                }
+            return remember { get$launcherName(context) }
+        }
+
+        fun get$launcherName(context: Context): $launcherName {
+            return $launcherName {
+                val intent = Intent(context, $activityName::class.java)
+                ${if (!isDefault) "intent.putExtra(\"launcher_destination\", \"${function.qualifiedName}\")" else ""}
+                context.startActivity(intent)
             }
         }
 
-        interface $launcherName {
+        fun interface $launcherName {
             fun launch()
         }
         """.trimIndent()

--- a/launcher-processor/src/test/kotlin/com/moriatsushi/launcher/processor/LauncherProcessorTest.kt
+++ b/launcher-processor/src/test/kotlin/com/moriatsushi/launcher/processor/LauncherProcessorTest.kt
@@ -76,7 +76,8 @@ class LauncherProcessorTest {
 
         val launcherCode = launcherFile!!.readText()
         assertThat(launcherCode).contains("\npackage testPackage\n")
-        assertThat(launcherCode).contains("fun rememberMainLauncher(): MainLauncher")
+        assertThat(launcherCode).contains("@Composable\nfun rememberMainLauncher(): MainLauncher")
+        assertThat(launcherCode).contains("fun getMainLauncher(context: Context): MainLauncher")
         assertThat(launcherCode).contains("interface MainLauncher")
         assertThat(launcherCode).contains("DefaultComposeActivity::class.java")
     }
@@ -146,7 +147,8 @@ class LauncherProcessorTest {
 
         val launcherCode = launcherFile!!.readText()
         assertThat(launcherCode).contains("\npackage testPackage\n")
-        assertThat(launcherCode).contains("fun rememberOtherLauncher(): OtherLauncher")
+        assertThat(launcherCode).contains("@Composable\nfun rememberOtherLauncher(): OtherLauncher")
+        assertThat(launcherCode).contains("fun getOtherLauncher(context: Context): OtherLauncher")
         assertThat(launcherCode).contains("interface OtherLauncher")
         assertThat(launcherCode).contains("ComposeActivity::class.java")
         assertThat(launcherCode).contains("intent.putExtra(\"launcher_destination\", \"testPackage.Other\")")

--- a/test/src/sharedTest/kotlin/com/moriatsushi/launcher/test/LauncherAndroidTest.kt
+++ b/test/src/sharedTest/kotlin/com/moriatsushi/launcher/test/LauncherAndroidTest.kt
@@ -1,7 +1,7 @@
 package com.moriatsushi.launcher.test
 
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.activity.ComponentActivity
+import androidx.test.core.app.launchActivity
 import androidx.test.espresso.intent.Intents
 import androidx.test.espresso.intent.Intents.intended
 import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
@@ -11,15 +11,11 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.hamcrest.core.AllOf.allOf
 import org.junit.After
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-class LauncherTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
-
+class LauncherAndroidTest {
     @Before
     fun setup() {
         Intents.init()
@@ -32,11 +28,10 @@ class LauncherTest {
 
     @Test
     fun `launch DefaultComposeActivity`() {
-        composeTestRule.setContent {
-            val launcher = rememberMainLauncher()
-            LaunchedEffect(Unit) {
-                launcher.launch()
-            }
+        val scenario = launchActivity<ComponentActivity>()
+        scenario.onActivity {
+            val launcher = getMainLauncher(it)
+            launcher.launch()
         }
         val expectedClass = "com.moriatsushi.launcher.DefaultComposeActivity"
         intended(hasComponent(hasClassName(expectedClass)))
@@ -44,11 +39,10 @@ class LauncherTest {
 
     @Test
     fun `launch ComposeActivity`() {
-        composeTestRule.setContent {
-            val launcher = rememberOther1Launcher()
-            LaunchedEffect(Unit) {
-                launcher.launch()
-            }
+        val scenario = launchActivity<ComponentActivity>()
+        scenario.onActivity {
+            val launcher = getOther1Launcher(it)
+            launcher.launch()
         }
         val expectedClass = "com.moriatsushi.launcher.ComposeActivity"
         val expectedDestination = "com.moriatsushi.launcher.test.Other1"

--- a/test/src/sharedTest/kotlin/com/moriatsushi/launcher/test/LauncherComposableTest.kt
+++ b/test/src/sharedTest/kotlin/com/moriatsushi/launcher/test/LauncherComposableTest.kt
@@ -1,0 +1,62 @@
+package com.moriatsushi.launcher.test
+
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.Intents.intended
+import androidx.test.espresso.intent.matcher.ComponentNameMatchers.hasClassName
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasComponent
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasExtra
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.hamcrest.core.AllOf.allOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class LauncherComposableTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun setup() {
+        Intents.init()
+    }
+
+    @After
+    fun clear() {
+        Intents.release()
+    }
+
+    @Test
+    fun `launch DefaultComposeActivity`() {
+        composeTestRule.setContent {
+            val launcher = rememberMainLauncher()
+            LaunchedEffect(Unit) {
+                launcher.launch()
+            }
+        }
+        val expectedClass = "com.moriatsushi.launcher.DefaultComposeActivity"
+        intended(hasComponent(hasClassName(expectedClass)))
+    }
+
+    @Test
+    fun `launch ComposeActivity`() {
+        composeTestRule.setContent {
+            val launcher = rememberOther1Launcher()
+            LaunchedEffect(Unit) {
+                launcher.launch()
+            }
+        }
+        val expectedClass = "com.moriatsushi.launcher.ComposeActivity"
+        val expectedDestination = "com.moriatsushi.launcher.test.Other1"
+        intended(
+            allOf(
+                hasComponent(hasClassName(expectedClass)),
+                hasExtra("launcher_destination", expectedDestination),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
#1 

* Allow to start Entry in a way that is not a Composable function

```kotlin
// from Composable
@Composable
fun Sample() {
    val launcher = rememberOtherEntryLauncher()
    LaunchedEffect(Unit) {
        launcher.launch()
    }
}
```

```kotlin
// from Activity
class SampleActivity: ComponentActivity() {
    private val launcher = getOtherLauncher(this)

    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)
        launcher.launch()
    }
}
```